### PR TITLE
Reject when DBread returns an error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -198,7 +198,7 @@ class S7Client extends EventEmitter {
       });
       debug(`${this.opts.name}: ReadDB DB=${DBNr}, Offset=${offset}, Length=${end - offset}`);
       this.client.DBRead(DBNr, offset, end - offset, (err, res) => {
-        if(err) reject(this._getErr(err));
+        if(err) return reject(this._getErr(err));
         resolve(vars.map(v => {
           v.value = datatypes[v.type].parser(res, v.start - offset, v.bit);
           this.emit('value', v);
@@ -232,7 +232,7 @@ class S7Client extends EventEmitter {
       });
 
       this.client.ReadMultiVars(toRead, (err, res) => {
-        if(err) reject(this._getErr(err));
+        if(err) return reject(this._getErr(err));
         let errs = [];
         res = vars.map((v, i) => {
           if(res[i].Result !== 0) return errs.push(this.client.ErrorText(res[i].Result));
@@ -270,7 +270,7 @@ class S7Client extends EventEmitter {
 
     return new Promise((resolve, reject) => {
       this.client.WriteMultiVars(toWrite, (err, res) => {
-        if(err) reject(this._getErr(err));
+        if(err) return reject(this._getErr(err));
         let errs = [];
 
         res = vars.map((v, i) => {

--- a/src/index.js
+++ b/src/index.js
@@ -198,7 +198,7 @@ class S7Client extends EventEmitter {
       });
       debug(`${this.opts.name}: ReadDB DB=${DBNr}, Offset=${offset}, Length=${end - offset}`);
       this.client.DBRead(DBNr, offset, end - offset, (err, res) => {
-        if(err) return this._getErr(err);
+        if(err) reject(this._getErr(err));
         resolve(vars.map(v => {
           v.value = datatypes[v.type].parser(res, v.start - offset, v.bit);
           this.emit('value', v);

--- a/src/index.js
+++ b/src/index.js
@@ -232,7 +232,7 @@ class S7Client extends EventEmitter {
       });
 
       this.client.ReadMultiVars(toRead, (err, res) => {
-        if(err) return this._getErr(err);
+        if(err) reject(this._getErr(err));
         let errs = [];
         res = vars.map((v, i) => {
           if(res[i].Result !== 0) return errs.push(this.client.ErrorText(res[i].Result));
@@ -270,7 +270,7 @@ class S7Client extends EventEmitter {
 
     return new Promise((resolve, reject) => {
       this.client.WriteMultiVars(toWrite, (err, res) => {
-        if(err) return this._getErr(err);
+        if(err) reject(this._getErr(err));
         let errs = [];
 
         res = vars.map((v, i) => {


### PR DESCRIPTION
Hi Christoph,

s7client is a really great library, thank you very much for offering it to the community!

I am wondering if the promise could just reject when the DBread returns an error? Background: We want to know when the reading from PLC fails and react accordingly in our application. Right now, there is no way to know because the promise will never be resolved/rejected in that case, it will just be hanging in the pending state.

Did I get that right or am I missing something?

Also, if you are interested, I can add a pull request for the typings we wrote in the project.

Thanks!

Best
Chris
