### PR TITLE
Disconnect on alive signal error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -126,6 +126,9 @@ class S7Client extends EventEmitter {
       // send a keep alive request every nth aliveCheck cycle
       if(this.opts.alivePkgCycl !== false && cnt >= this.opts.alivePkgCycle) {
         this.client.PlcStatus((err, res) => {
+          if(err) {
+            this.client.Disconnect();
+          }
         });
         cnt = 0;
       }


### PR DESCRIPTION
Hallo Christoph,

wir haben festgestellt, dass im Falle eines Kontaktabbruchs (Strom aus, Stecker wird rausgezogen, Netzwerk wird gewechselt, etc.) zwischen dem Client und der SPS kein "disconnect" Event gefeuert wird. Scheinbar bekommt der client von node-snap7 das nicht mit und daher wird in Zeile 133 bei client.Connected() noch true zurückgegeben. Damit ist die Verbindung dauerhaft weg, auch wenn die SPS wieder online ist.

Wenn manuell disconnected wird, kann das Problem umgangen werden.

Das Problem kann z.B. reproduziert weden, indem der Server in einem anderen Prozess gestartet und dann gekillt wird.

Ich werde versuchen, unit tests dafür zu schreiben, wäre aber dankbar, wenn du Zeit findest dir das kurz anzuschauen.

Viele Grüße
Chris